### PR TITLE
Add split-by-state task to split merged file by state.

### DIFF
--- a/farmfresh/scraper/Makefile
+++ b/farmfresh/scraper/Makefile
@@ -3,6 +3,7 @@ RAW=$(OUT)/raw
 JSON=$(OUT)/json
 CANONICAL=$(OUT)/canonical
 MERGED=$(OUT)/merged
+STATES=$(OUT)/states
 
 clean:
 	rm -rf $(OUT)
@@ -10,8 +11,9 @@ clean:
 	mkdir -p $(JSON)
 	mkdir -p $(CANONICAL)
 	mkdir -p $(MERGED)
+	mkdir -p $(STATES)
 
-all: clean farmersmarkets onfarmmarkets merge
+all: clean farmersmarkets onfarmmarkets merge split-by-state
 
 farmersmarkets:
 	curl -o $(RAW)/farmersmarkets.csv https://search.ams.usda.gov/farmersmarkets/ExcelExport.aspx
@@ -28,3 +30,6 @@ merge:
 	python canonicalize.py $(JSON)/farmersmarkets.json > $(CANONICAL)/farmersmarkets.json
 	jq -s '[.[][]]' $(CANONICAL)/onfarmmarkets.json $(CANONICAL)/farmersmarkets.json > $(MERGED)/merged.json
 	jq -r '(map(keys) | add | unique) as $$cols | map(. as $$row | $$cols | map($$row[.])) as $$rows | $$cols, $$rows[] | @csv' $(MERGED)/merged.json > $(MERGED)/merged.csv
+
+split-by-state:
+	INPUT=$(MERGED)/merged.json OUTPUT=$(STATES) ./split-by-state.sh

--- a/farmfresh/scraper/split-by-state.sh
+++ b/farmfresh/scraper/split-by-state.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+jq -rc 'group_by(.state)[] | "\(.[0].state)\t\(.)"' ${INPUT} |
+  while IFS=$'\t' read -r state content; do
+    mkdir -p "${OUTPUT}/${state}"
+    JSON=${OUTPUT}/${state}/markets.json
+    echo "${content}" > "${JSON}"
+
+    CSV="${OUTPUT}/${state}/markets.csv"
+    jq -r '(map(keys) | add | unique) as $cols | map(. as $row | $cols | map($row[.])) as $rows | $cols, $rows[] | @csv' "${JSON}" > "${CSV}"
+  done


### PR DESCRIPTION
This PR adds a `split-by-state` task to the farmfresh scraper.

The `make all` command will now generate the merged results into `out/merged`, and also a folder called `out/states/`, into which the data is bucketed by state name.